### PR TITLE
Fix comment in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,8 +16,7 @@ DO NOT DELETE ANY TEXT from this template! Otherwise the issue may be closed wit
 
 **Operating environment/Installation (Hass.io/Docker/pip/etc.):**
 <!--
-Please provide details about your environment below the '-->'.
--->
+Please provide details about your environment below this line. -->
 
 **ESP (ESP32/ESP8266, Board/Sonoff):**
 <!--


### PR DESCRIPTION
The `-->` which was intended to be within the comment was closing it instead, turning the intended end of the comment into visible content.

To aid clarity, the closing comment is moved inline; otherwise, the instruction to type after the HTML comment would become convoluted.  This does result in this comment being different to all others, whose endings are on new lines; I haven't changed them all, but it would certainly be possible to do so if desired for maximum consistency.