### PR TITLE
Replace broken Discord invite link with working one

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Creating a bug report here is the best way to coordinate who wants to implement 
 
 **Documentation:** https://esphome.io/
 
-**Discord Chat:** https://discord.gg/DrAFdq4
+**Discord Chat:** https://discord.gg/KhAMKrd
 
 For feature requests, please see [feature requests](https://github.com/esphome/feature-requests/issues).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Creating a bug report here is the best way to coordinate who wants to implement 
 
 **Documentation:** https://esphome.io/
 
-**Discord Chat:** https://discord.gg/KhAMKr
+**Discord Chat:** https://discord.gg/DrAFdq4
 
 For feature requests, please see [feature requests](https://github.com/esphome/feature-requests/issues).


### PR DESCRIPTION
new invite link has no expiry or max user limit set and should continue to work indefinitely