### PR TITLE
`dashboard`→`device-builder`

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,9 +9,9 @@ contact_links:
   - name: Report an issue with the ESPHome web server
     url: https://github.com/esphome/esphome-webserver/issues/new/choose
     about: Report an issue with the ESPHome web server.
-  - name: Report an issue with the ESPHome Builder / Dashboard
-    url: https://github.com/esphome/dashboard/issues/new/choose
-    about: Report an issue with the ESPHome Builder / Dashboard.
+  - name: Report an issue with the ESPHome Device Builder Dashboard
+    url: https://github.com/esphome/device-builder/issues/new/choose
+    about: Report an issue with the ESPHome Device Builder Dashboard.
   - name: Report an issue with the ESPHome API client
     url: https://github.com/esphome/aioesphomeapi/issues/new/choose
     about: Report an issue with the ESPHome API client.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Issues are no longer accepted here, please use the relevant repository for your issue:
 
 - [ESPHome](https://github.com/esphome/esphome/issues) – for compilation issues, runtime crashes and other core issues
-- [Dashboard](https://github.com/esphome/dashboard/issues) – for ESPHome Builder / Dashboard bugs
+- [Device Builder Dashboard](https://github.com/esphome/device-builder/issues) – for ESPHome Device Builder Dashboard bugs
 - [Documentation](https://github.com/esphome/esphome.io/issues) - for issues with the ESPHome website and documentation
 - [aioesphomeapi](https://github.com/esphome/aioesphomeapi/issues) - Python API client issues
 - [Home Assistant](https://github.com/home-assistant/core/issues) - For issues that come up inside Home Assistant while using ESPHome devices


### PR DESCRIPTION
“Builder Dashboard” would be a shorter name, but based on https://github.com/esphome/device-builder/blob/70b0967560e37f48422570e4defe0c7f963d407f/README.md?plain=1#L1
`# ESPHome Device Builder Dashboard`
“Device Builder Dashboard” is the correct name.

trying to follow the old link to create an issue causes an error
> ⚠️ This repository was archived by the owner on Jul 20, 2026. It is now read-only.

Edit: there are similar issues in other esphome repos which I'll PR once this is merged